### PR TITLE
Updating computation of R and I to be more efficient

### DIFF
--- a/Functions/Core_MPT/Mat_Method_Calc_Imag_Part.py
+++ b/Functions/Core_MPT/Mat_Method_Calc_Imag_Part.py
@@ -10,7 +10,6 @@ def Mat_Method_Calc_Imag_Part(Array: np.ndarray,
                               fes2: comp.HCurl,
                               mesh: comp.Mesh,
                               inout: fem.CoefficientFunction,
-                              mu_inv: comp.GridFunction,
                               alpha: float,
                               Sols: np.ndarray,
                               sigma: comp.GridFunction,
@@ -75,17 +74,23 @@ def Mat_Method_Calc_Imag_Part(Array: np.ndarray,
         read_vec.FV().NumPy()[:] = Theta0Sol[:, 0]
         with TaskManager():
             A.Apply(read_vec, write_vec)
-        A_mat_t0_1 = write_vec.FV().NumPy()
+        A_mat_t0_1[:] = write_vec.FV().NumPy()
+        
+        read_vec = GridFunction(fes2).vec.CreateVector()
+        write_vec = GridFunction(fes2).vec.CreateVector()
         
         read_vec.FV().NumPy()[:] = Theta0Sol[:, 1]
         with TaskManager():
             A.Apply(read_vec, write_vec)
-        A_mat_t0_2 = write_vec.FV().NumPy()
+        A_mat_t0_2[:] = write_vec.FV().NumPy()
+        
+        read_vec = GridFunction(fes2).vec.CreateVector()
+        write_vec = GridFunction(fes2).vec.CreateVector()
         
         read_vec.FV().NumPy()[:] = Theta0Sol[:, 2]
         with TaskManager():
             A.Apply(read_vec, write_vec)
-        A_mat_t0_3 = write_vec.FV().NumPy()
+        A_mat_t0_3[:] = write_vec.FV().NumPy()
     
     
     # if ReducedSolve is False then the A matrix is not shrunk and there is no point in multiplying it with anything.
@@ -125,8 +130,8 @@ def Mat_Method_Calc_Imag_Part(Array: np.ndarray,
             with TaskManager():
                 A.Apply(read_vec, write_vec)
             TU2[:, i] = write_vec.FV().NumPy()
-            T22 = np.conj(np.transpose(u2Truncated)) @ TU2
-            T32 = np.conj(np.transpose(u3Truncated)) @ TU2
+        T22 = np.conj(np.transpose(u2Truncated)) @ TU2
+        T32 = np.conj(np.transpose(u3Truncated)) @ TU2
         del TU2
         
         # Same as before.
@@ -136,7 +141,7 @@ def Mat_Method_Calc_Imag_Part(Array: np.ndarray,
             with TaskManager():
                 A.Apply(read_vec, write_vec)
             TU3[:, i] = write_vec.FV().NumPy()
-            T33 = np.conj(np.transpose(u3Truncated)) @ TU3
+        T33 = np.conj(np.transpose(u3Truncated)) @ TU3
         del TU3
         
     # At this stage, all the work relating to the large bilinear form A has been completed. All the remaining matrix multiplications

--- a/Functions/Core_MPT/Mat_Method_Calc_Imag_Part.py
+++ b/Functions/Core_MPT/Mat_Method_Calc_Imag_Part.py
@@ -1,0 +1,314 @@
+import numpy as np
+from ngsolve import *
+import scipy.sparse as sp
+import gc
+
+def Mat_Method_Calc_Imag_Part(Array: np.ndarray, 
+                              Integration_Order: int,
+                              Theta0Sol: np.ndarray,
+                              bilinear_bonus_int_order: int,
+                              fes2: comp.HCurl,
+                              mesh: comp.Mesh,
+                              inout: fem.CoefficientFunction,
+                              mu_inv: comp.GridFunction,
+                              alpha: float,
+                              Sols: np.ndarray,
+                              sigma: comp.GridFunction,
+                              u1Truncated,
+                              u2Truncated,
+                              u3Truncated,
+                              xivec: list,
+                              NumSolverThreads: int | str,
+                              drop_tol: float | None,
+                              BigProblem: bool,
+                              ReducedSolve=True) -> np.ndarray:
+    
+    
+    if NumSolverThreads != 'default':
+        SetNumThreads(NumSolverThreads)
+    
+    u, v = fes2.TnT()
+    ndof2 = fes2.ndof
+    cutoff = u1Truncated.shape[1]
+    
+    A = BilinearForm(fes2, symmetric=True, delete_zero_elements =drop_tol,keep_internal=False, symmetric_storage=True)
+    A += SymbolicBFI(sigma * inout * (v * u), bonus_intorder=bilinear_bonus_int_order)
+    
+    if BigProblem is False or ReducedSolve is False:
+        with TaskManager():
+            A.Assemble()
+        rows, cols, vals = A.mat.COO()
+        del A
+        A_matsym = sp.csr_matrix((vals, (rows, cols)),shape=(fes2.ndof,fes2.ndof))
+        del rows, cols, vals
+        A_mat = A_matsym + A_matsym.T - sp.diags(A_matsym.diagonal())
+        del A_matsym
+        gc.collect()
+    
+    # E and G are both small compared to A so storing them shouldn't be an issue.
+    E = np.zeros((3, fes2.ndof), dtype=complex)
+    G = np.zeros((3, 3))
+    
+    for i in range(3):
+        E_lf = LinearForm(fes2)
+        E_lf += SymbolicLFI(sigma * inout * xivec[i] * v, bonus_intorder=bilinear_bonus_int_order)
+        E_lf.Assemble()
+        E[i, :] = E_lf.vec.FV().NumPy()[:]
+        del E_lf
+        
+        for j in range(3):
+            G[i, j] = Integrate(sigma * inout * xivec[i] * xivec[j], mesh, order=Integration_Order)
+    H = E.transpose()
+    
+    
+    if BigProblem is False:
+        A_mat_t0_1 = (A_mat) @ Theta0Sol[:, 0]
+        A_mat_t0_2 = (A_mat) @ Theta0Sol[:, 1]
+        A_mat_t0_3 = (A_mat) @ Theta0Sol[:, 2]
+    else:
+        A_mat_t0_1 = np.zeros(ndof2, dtype=complex)
+        A_mat_t0_2 = np.zeros(ndof2, dtype=complex)
+        A_mat_t0_3 = np.zeros(ndof2, dtype=complex)
+        read_vec = GridFunction(fes2).vec.CreateVector()
+        write_vec = GridFunction(fes2).vec.CreateVector()
+        
+        read_vec.FV().NumPy()[:] = Theta0Sol[:, 0]
+        with TaskManager():
+            A.Apply(read_vec, write_vec)
+        A_mat_t0_1 = write_vec.FV().NumPy()
+        
+        read_vec.FV().NumPy()[:] = Theta0Sol[:, 1]
+        with TaskManager():
+            A.Apply(read_vec, write_vec)
+        A_mat_t0_2 = write_vec.FV().NumPy()
+        
+        read_vec.FV().NumPy()[:] = Theta0Sol[:, 2]
+        with TaskManager():
+            A.Apply(read_vec, write_vec)
+        A_mat_t0_3 = write_vec.FV().NumPy()
+    
+    
+    # if ReducedSolve is False then the A matrix is not shrunk and there is no point in multiplying it with anything.
+    if BigProblem is False:
+        # (𝐂)^M being the reduced MxM complex matrix. Similarly to the real part, we store each combination of i,j.
+        if ReducedSolve == True:
+            T11 = np.conj(np.transpose(u1Truncated)) @ A_mat @ u1Truncated
+            T22 = np.conj(np.transpose(u2Truncated)) @ A_mat @ u2Truncated
+            T33 = np.conj(np.transpose(u3Truncated)) @ A_mat @ u3Truncated
+            T21 = np.conj(np.transpose(u2Truncated)) @ A_mat @ u1Truncated
+            T31 = np.conj(np.transpose(u3Truncated)) @ A_mat @ u1Truncated
+            T32 = np.conj(np.transpose(u3Truncated)) @ A_mat @ u2Truncated
+        else:
+            T11 = T22 = T33 = T21 = T31 = T32 = A_mat
+            
+    else:
+        # Reducing size of K matrix
+        TU1 = np.zeros([ndof2, cutoff], dtype=complex)
+        read_vec = GridFunction(fes2).vec.CreateVector()
+        write_vec = GridFunction(fes2).vec.CreateVector()
+        
+        # For each column in u1Truncated, post multiply with K. We then premultiply by appropriate vector to reduce size to MxM.
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u1Truncated[:, i]
+            with TaskManager():
+                A.Apply(read_vec, write_vec)
+            TU1[:, i] = write_vec.FV().NumPy()
+        T11 = np.conj(np.transpose(u1Truncated)) @ TU1
+        T21 = np.conj(np.transpose(u2Truncated)) @ TU1
+        T31 = np.conj(np.transpose(u3Truncated)) @ TU1
+        del TU1
+        
+        # Same as before
+        TU2 = np.zeros([ndof2, cutoff], dtype=complex)
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u2Truncated[:, i]
+            with TaskManager():
+                A.Apply(read_vec, write_vec)
+            TU2[:, i] = write_vec.FV().NumPy()
+            T22 = np.conj(np.transpose(u2Truncated)) @ TU2
+            T32 = np.conj(np.transpose(u3Truncated)) @ TU2
+        del TU2
+        
+        # Same as before.
+        TU3 = np.zeros([ndof2, cutoff], dtype=complex)
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u3Truncated[:, i]
+            with TaskManager():
+                A.Apply(read_vec, write_vec)
+            TU3[:, i] = write_vec.FV().NumPy()
+            T33 = np.conj(np.transpose(u3Truncated)) @ TU3
+        del TU3
+        
+    # At this stage, all the work relating to the large bilinear form A has been completed. All the remaining matrix multiplications
+    # concern smaller matrices and so BigProblem is no longer considered.
+    
+    if BigProblem is False:
+        # At this point, we have constructed each of the main matrices we need and obtained the reduced A matrix. The
+        # larger bilinear form can therefore be removed to save memory.
+        del A_mat
+    
+    
+    # At0_array = [A_mat_t0_1, A_mat_t0_2, A_mat_t0_3]
+    # Here we compute (𝐨ⱼ)ᵀ (̅𝐂²)ᴹ
+    # Renamed to better fit naming convention
+    if ReducedSolve == True:
+        UAt011_conj = np.conj(u1Truncated.transpose()) @ A_mat_t0_1
+        UAt022_conj = np.conj(u2Truncated.transpose()) @ A_mat_t0_2
+        UAt033_conj = np.conj(u3Truncated.transpose()) @ A_mat_t0_3
+        UAt012_conj = np.conj(u1Truncated.transpose()) @ A_mat_t0_2
+        UAt013_conj = np.conj(u1Truncated.transpose()) @ A_mat_t0_3
+        UAt023_conj = np.conj(u2Truncated.transpose()) @ A_mat_t0_3
+    else:
+        UAt011_conj = A_mat_t0_1
+        UAt022_conj = UAt012_conj = A_mat_t0_2
+        UAt033_conj =  UAt013_conj = UAt023_conj = A_mat_t0_3
+        
+    # UAt0_conj = [UAt011_conj, UAt022_conj, UAt033_conj, UAt012_conj, UAt013_conj, UAt023_conj]
+    # Similarly we compute and store (𝐨ⱼ)ᵀ (𝐂²)ᴹ
+    if ReducedSolve == True:
+        UAt011 = (u1Truncated.transpose()) @ A_mat_t0_1
+        UAt022 = (u2Truncated.transpose()) @ A_mat_t0_2
+        UAt033 = (u3Truncated.transpose()) @ A_mat_t0_3
+        UAt021 = (u2Truncated.transpose()) @ A_mat_t0_1
+        UAt031 = (u3Truncated.transpose()) @ A_mat_t0_1
+        UAt032 = (u3Truncated.transpose()) @ A_mat_t0_2
+    else:
+        UAt011 = UAt021 = UAt031 = A_mat_t0_1
+        UAt022 = UAt032 = A_mat_t0_2
+        UAt033 = A_mat_t0_3
+    
+    # UAt0U_array = [UAt011, UAt022, UAt033, UAt021, UAt031, UAt032]
+    # Finally, we can construct constants that do not depend on frequency.
+    # the constant c1 corresponds to 𝐨ⱼᵀ 𝐂⁽¹⁾ 𝐨ᵢ. Similar to other cases we store each combination of i and j.
+    c1_11 = (np.transpose(Theta0Sol[:, 0])) @ A_mat_t0_1
+    c1_22 = (np.transpose(Theta0Sol[:, 1])) @ A_mat_t0_2
+    c1_33 = (np.transpose(Theta0Sol[:, 2])) @ A_mat_t0_3
+    c1_21 = (np.transpose(Theta0Sol[:, 1])) @ A_mat_t0_1
+    c1_31 = (np.transpose(Theta0Sol[:, 2])) @ A_mat_t0_1
+    c1_32 = (np.transpose(Theta0Sol[:, 2])) @ A_mat_t0_2
+    # c5 corresponds to 𝐬ᵢᵀ 𝐨ⱼ. Note that E has been transposed here.
+    c5_11 = E[0, :] @ Theta0Sol[:, 0]
+    c5_22 = E[1, :] @ Theta0Sol[:, 1]
+    c5_33 = E[2, :] @ Theta0Sol[:, 2]
+    c5_21 = E[1, :] @ Theta0Sol[:, 0]
+    c5_31 = E[2, :] @ Theta0Sol[:, 0]
+    c5_32 = E[2, :] @ Theta0Sol[:, 1]
+    # Similarly to other examples we store each combination rather than recompute
+    # c1_array = [c1_11, c1_22, c1_33, c1_21, c1_31, c1_32]
+    # c5_array = [c5_11, c5_22, c5_33, c5_21, c5_31, c5_32]
+    # c7 = G corresponds to cᵢⱼ from paper. Note that G does not depend on the FEM basis functions, rather is a
+    # polynomial.
+    c7 = G
+    # c8 corresponds to  𝐬ⱼᵀ 𝐨ᵢ and shold equal c5 for on diagonal entries.
+    c8_11 = Theta0Sol[:, 0] @ H[:, 0]
+    c8_22 = Theta0Sol[:, 1] @ H[:, 1]
+    c8_33 = Theta0Sol[:, 2] @ H[:, 2]
+    c8_21 = Theta0Sol[:, 1] @ H[:, 0]
+    c8_31 = Theta0Sol[:, 2] @ H[:, 0]
+    c8_32 = Theta0Sol[:, 2] @ H[:, 1]
+    # c8_array = [c8_11, c8_22, c8_33, c8_21, c8_31, c8_32]
+    # EU is the reduced linear form for E. Here we compute (̅𝐭ᴹ)ᵀ.
+    if ReducedSolve == True:
+        EU_11 = E[0, :] @ np.conj(u1Truncated)
+        EU_22 = E[1, :] @ np.conj(u2Truncated)
+        EU_33 = E[2, :] @ np.conj(u3Truncated)
+        EU_21 = E[1, :] @ np.conj(u1Truncated)
+        EU_31 = E[2, :] @ np.conj(u1Truncated)
+        EU_32 = E[2, :] @ np.conj(u2Truncated)
+    else:
+        EU_11 = E[0, :]
+        EU_22 = EU_21 = E[1, :]
+        EU_33 = EU_31 = EU_32 = E[2, :]
+    # EU_array_conj = [EU_11, EU_22, EU_33, EU_21, EU_31, EU_32]
+    H = E.transpose()
+    # also computing  (𝐭ᴹ)ᵀ
+    # Renamed to better fit naming convention
+    if ReducedSolve == True:
+        UH_11 = u1Truncated.transpose() @ H[:, 0]
+        UH_22 = u2Truncated.transpose() @ H[:, 1]
+        UH_33 = u3Truncated.transpose() @ H[:, 2]
+        UH_21 = u2Truncated.transpose() @ H[:, 0]
+        UH_31 = u3Truncated.transpose() @ H[:, 0]
+        UH_32 = u3Truncated.transpose() @ H[:, 1]
+    else:
+        UH_11 = UH_21 = UH_31 =  H[:, 0]
+        UH_22 = UH_32 =  H[:, 1]
+        UH_33 = H[:, 2]
+        
+    # UH_array = [UH_11, UH_22, UH_33, UH_21, UH_31, UH_32]
+    
+    # At this point, we have constrcted all of the matrices, vectors, and constants that need to be computed.
+    # We can now iterate through frequency and compute the tensor coefficients.
+    
+    # Computing Tensor Coefficients:
+    I = np.zeros([3, 3])
+    imag_part = np.zeros((Sols.shape[1], 9))
+    
+    # For each frequency pre and post multiply Q with the solution vector for i=0:3, j=0:i+1.
+    for k, omega in enumerate(Array):
+        
+        if ReducedSolve is True or BigProblem is False:
+            for i in range(3):
+                gi = np.squeeze(Sols[:,k,i])
+                for j in range(i + 1):
+                    gj = np.squeeze(Sols[:, k, j])
+                    
+                    UH = locals()[f'UH_{i+1}{j+1}']
+                    EU = locals()[f'EU_{i+1}{j+1}']
+                    T = locals()[f'T{i+1}{j+1}']
+                    c1 = locals()[f'c1_{i+1}{j+1}']
+                    c8 = locals()[f'c8_{i+1}{j+1}']
+                    c5 = locals()[f'c5_{i+1}{j+1}']
+                    UAt0 = locals()[f'UAt0{i+1}{j+1}']
+                    At0U = locals()[f'UAt0{j+1}{i+1}_conj']
+                    
+                    # Calc Imag Part:
+                    p1 = np.real(np.conj(gi) @ T @ gj)
+                    p2 = np.real(1 * np.conj(gj.transpose()) @  At0U)
+                    p2 += np.real(1 * gi.transpose() @ UAt0)
+                    p3 = np.real(c8 + c5)
+                    p4 = np.real(1 * EU @ np.conj(gj))
+                    p4 += np.real(1 * gi @ UH)
+
+                    I[i,j] = np.real((alpha ** 3 / 4) * omega * 4*np.pi*1e-7 * alpha ** 2 * (c1 + c7[i, j] + p1 + p2 + p3 + p4))
+        
+        # If we don't reduce the size of the matrix and we still want to save memory, then we can use K.Apply here as well.
+        if ReducedSolve is False and BigProblem is True:
+            
+            for i in range(3):
+                gi = np.squeeze(Sols[:,k,i])
+                for j in range(i + 1):
+                    gj = np.squeeze(Sols[:, k, j])
+                    UH = locals()[f'UH_{i+1}{j+1}']
+                    EU = locals()[f'EU_{i+1}{j+1}']
+                    T = locals()[f'T{i+1}{j+1}']
+                    c1 = locals()[f'c1_{i+1}{j+1}']
+                    c8 = locals()[f'c8_{i+1}{j+1}']
+                    c5 = locals()[f'c5_{i+1}{j+1}']
+                    UAt0 = locals()[f'UAt0{i+1}{j+1}']
+                    At0U = locals()[f'UAt0{j+1}{i+1}_conj']
+                    
+                    read_vec.FV().NumPy()[:] = gj
+                    with TaskManager():
+                        T.Apply(read_vec, write_vec)
+                    p1 = np.conj(gi) @ write_vec.FV().NumPy()[:]
+                    
+                    # Calc Imag Part:
+                    # p1 = np.real(np.conj(gi) @ T @ gj)
+                    p2 = np.real(1 * np.conj(gj.transpose()) @  At0U)
+                    p2 += np.real(1 * gi.transpose() @ UAt0)
+                    p3 = np.real(c8 + c5)
+                    p4 = np.real(1 * EU @ np.conj(gj))
+                    p4 += np.real(1 * gi @ UH)
+
+                    I[i,j] = np.real((alpha ** 3 / 4) * omega * 4*np.pi*1e-7 * alpha ** 2 * (c1 + c7[i, j] + p1 + p2 + p3 + p4))
+
+                    
+                
+                 
+        I += np.transpose(I - np.diag(np.diag(I))).real
+        imag_part[k,:] = I.flatten()
+        
+    return imag_part
+        
+        

--- a/Functions/Core_MPT/Mat_Method_Calc_Imag_Part.py
+++ b/Functions/Core_MPT/Mat_Method_Calc_Imag_Part.py
@@ -22,6 +22,45 @@ def Mat_Method_Calc_Imag_Part(Array: np.ndarray,
                               BigProblem: bool,
                               ReducedSolve=True) -> np.ndarray:
     
+    """
+    James Elgy - 2024.
+    Function to compute the imag tensor coefficients (I)_ij efficiently using the faster matrix method.
+    
+    1) Computes the bilinear form A
+    2) Computes matrices E, G, and H.
+    2) If reduced solve is True, reduce A to size MxM and E and H to size 3xM.
+    4) Compute additional matrices and vectors (𝐨ⱼ)ᵀ (̅𝐂²)ᴹ,  (𝐨ⱼ)ᵀ (𝐂²)ᴹ,  𝐨ⱼᵀ 𝐂⁽¹⁾ 𝐨ᵢ, 𝐬ᵢᵀ 𝐨ⱼ, 𝐬ⱼᵀ 𝐨ᵢ, and (𝐭ᴹ)ᵀ.
+    3) For each frequency, compute conj(q_i)^T A_ij (q_j)
+    4) Scale and compute (I)_ij
+    
+    If BigProblem is True, then a slower but more memory efficient implementation is used using A.Apply().
+    
+    Args:
+        Array (np.ndarray): Array of frequencies to consider.
+        Integration order (int): order to use for integration in Integrate function.
+        Theta0Sol (np.ndarray): ndof x 3 array of theta0 solutions.
+        bilinear_bonus_int_order (int): Integration order for the bilinear forms
+        fes2 (comp.HCurl): HCurl finite element space for the Theta1 problem.
+        mesh (comp.Mesh): ngsolve mesh.
+        inout (fem.CoefficientFunction): material coefficient function. 1 inside objects, 0 outside
+        alpha (float): object size scaling
+        Sols (np.ndarray): Ndof x nfreqs x 3 vector of solution coefficients.
+        sigma (comp.GridFunction): Grid Function for sigma. Note that for material discontinuities aligning with vertices no interpolation is done
+        u1Truncated (_type_): Ndof x M complex left singular matrix for e_1. If ReducedSolve is False, then replace U with sparse identity of size Ndof.
+        u2Truncated (_type_): Ndof x M complex left singular mactrix for e_2. If ReducedSolve is False, then replace U with sparse identity of size Ndof.
+        u3Truncated (_type_): Ndof x M complex left singular matrix for e_3. If ReducedSolve is False, then replace U with sparse identity of size Ndof.
+        xivec (list): 3x3 list of direction vectors
+        NumSolverThreads (int | str): Multithreading threads. If using all threads use 'default'.
+        drop_tol (float | None): During assembly entries < drop_tol are assumed to be 0. Use None to include all entries.
+        BigProblem (bool): if True then the code does not assemble the system matrix entirely. Slower but more memory efficient.
+        ReducedSolve (bool, optional): If True, the size of the multiplications are reduced to size M. Use with POD. Defaults to True.
+
+    Returns:
+        np.ndarray: Nfreq x 9 array of imag tensor coeffcients.
+    """
+    
+    if NumSolverThreads != 'default':
+        Se
     
     if NumSolverThreads != 'default':
         SetNumThreads(NumSolverThreads)
@@ -246,12 +285,12 @@ def Mat_Method_Calc_Imag_Part(Array: np.ndarray,
     # We can now iterate through frequency and compute the tensor coefficients.
     
     # Computing Tensor Coefficients:
-    I = np.zeros([3, 3])
+    
     imag_part = np.zeros((Sols.shape[1], 9))
     
     # For each frequency pre and post multiply Q with the solution vector for i=0:3, j=0:i+1.
     for k, omega in enumerate(Array):
-        
+        I = np.zeros([3, 3])
         if ReducedSolve is True or BigProblem is False:
             for i in range(3):
                 gi = np.squeeze(Sols[:,k,i])

--- a/Functions/Core_MPT/Mat_Method_Calc_Real_Part.py
+++ b/Functions/Core_MPT/Mat_Method_Calc_Real_Part.py
@@ -16,9 +16,35 @@ def Mat_Method_Calc_Real_Part(bilinear_bonus_int_order: int,
                               drop_tol: float | None,
                               BigProblem: bool,
                               ReducedSolve=True) -> np.ndarray:
+    """
+    James Elgy - 2024.
+    Function to compute the real tensor coefficients (R)_ij efficiently using the faster matrix method.
     
+    1) Computes the bilinear form K
+    2) If reduced solve is True, reduce K to size MxM
+    3) For each frequency, compute conj(q_i)^T Q_ij (q_j)
+    4) Scale and compute (R)_ij
+    
+    If BigProblem is True, then a slower but more memory efficient implementation is used using K.Apply().
+    
+    Args:
+        bilinear_bonus_int_order (int): Integration order for the bilinear forms
+        fes2 (comp.HCurl): HCurl finite element space for the Theta1 problem.
+        inout (fem.CoefficientFunction): material coefficient function. 1 inside objects, 0 outside
+        mu_inv (comp.GridFunction): grid function for 1/mu_r. Note that for material discontinuities aligning with vertices no interpolation is done.
+        alpha (float): object size scaling
+        Sols (np.ndarray): Ndof x nfreqs x 3 vector of solution coefficients.
+        u1Truncated (_type_): Ndof x M complex left singular matrix for e_1. If ReducedSolve is False, then replace U with sparse identity of size Ndof.
+        u2Truncated (_type_): Ndof x M complex left singular mactrix for e_2. If ReducedSolve is False, then replace U with sparse identity of size Ndof.
+        u3Truncated (_type_): Ndof x M complex left singular matrix for e_3. If ReducedSolve is False, then replace U with sparse identity of size Ndof.
+        NumSolverThreads (int | str): Multithreading threads. If using all threads use 'default'.
+        drop_tol (float | None): During assembly entries < drop_tol are assumed to be 0. Use None to include all entries.
+        BigProblem (bool): if True then the code does not assemble the system matrix entirely. Slower but more memory efficient.
+        ReducedSolve (bool, optional): If True, the size of the multiplications are reduced to size M. Use with POD. Defaults to True.
 
-    
+    Returns:
+        np.ndarray: Nfreq x 9 array of real tensor coeffcients.
+    """
     
     if NumSolverThreads != 'default':
         SetNumThreads(NumSolverThreads)
@@ -78,8 +104,8 @@ def Mat_Method_Calc_Real_Part(bilinear_bonus_int_order: int,
             with TaskManager():
                 K.Apply(read_vec, write_vec)
             QU2[:, i] = write_vec.FV().NumPy()
-            Q22 = np.conj(np.transpose(u2Truncated)) @ QU2
-            Q32 = np.conj(np.transpose(u3Truncated)) @ QU2
+        Q22 = np.conj(np.transpose(u2Truncated)) @ QU2
+        Q32 = np.conj(np.transpose(u3Truncated)) @ QU2
         del QU2
         
         # Same as before.
@@ -89,26 +115,26 @@ def Mat_Method_Calc_Real_Part(bilinear_bonus_int_order: int,
             with TaskManager():
                 K.Apply(read_vec, write_vec)
             QU3[:, i] = write_vec.FV().NumPy()
-            Q33 = np.conj(np.transpose(u3Truncated)) @ QU3
+        Q33 = np.conj(np.transpose(u3Truncated)) @ QU3
 
                 
     # Computing Tensor Coefficients:
-    R = np.zeros([3, 3])
+
     real_part = np.zeros((Sols.shape[1], 9))
     
     # For each frequency pre and post multiply Q with the solution vector for i=0:3, j=0:i+1.
-    for k in range(np.squeeze(Sols).shape[1]):
-        
+    for k in range(Sols.shape[1]):
+        R = np.zeros([3, 3])
         
         # if ReducedSolve is True then the matrices are small so we can just multiply them.
         if ReducedSolve is True or BigProblem is False:
             for i in range(3):
-                gi = np.squeeze(Sols[:,k,i])
+                gi = np.squeeze(Sols[:,k, i])
                 for j in range(i + 1):
+                    gj = np.squeeze(Sols[:, k, j])
 
                     Qij = locals()[f'Q{i+1}{j+1}']
 
-                    gj = np.squeeze(Sols[:, k, j])
                     A = np.conj(gi[None, :]) @ Qij @ (gj)[:, None]
                     R[i, j] = (A * (-alpha ** 3) / 4).real
 

--- a/Functions/Core_MPT/Mat_Method_Calc_Real_Part.py
+++ b/Functions/Core_MPT/Mat_Method_Calc_Real_Part.py
@@ -1,0 +1,133 @@
+import numpy as np
+from ngsolve import *
+import scipy.sparse as sp
+import gc
+
+def Mat_Method_Calc_Real_Part(bilinear_bonus_int_order: int,
+                              fes2: comp.HCurl,
+                              inout: fem.CoefficientFunction,
+                              mu_inv: comp.GridFunction,
+                              alpha: float,
+                              Sols: np.ndarray,
+                              u1Truncated,
+                              u2Truncated,
+                              u3Truncated,
+                              NumSolverThreads: int | str,
+                              drop_tol: float | None,
+                              BigProblem: bool,
+                              ReducedSolve=True) -> np.ndarray:
+    
+
+    
+    
+    if NumSolverThreads != 'default':
+        SetNumThreads(NumSolverThreads)
+    
+    u, v = fes2.TnT()
+    ndof2 = fes2.ndof
+    cutoff = u1Truncated.shape[1]
+    K = BilinearForm(fes2, symmetric=True, delete_zero_elements =drop_tol,keep_internal=False, symmetric_storage=True)
+    K += SymbolicBFI(inout * mu_inv * curl(u) * Conj(curl(v)), bonus_intorder=bilinear_bonus_int_order)
+    K += SymbolicBFI((1 - inout) * curl(u) * Conj(curl(v)), bonus_intorder=bilinear_bonus_int_order)
+    
+    if BigProblem is False or ReducedSolve is False:
+        with TaskManager():
+            K.Assemble()
+        rows, cols, vals = K.mat.COO()
+        del K
+        Qsym = sp.csr_matrix((vals, (rows, cols)),shape=(fes2.ndof,fes2.ndof))
+        Q = Qsym + Qsym.T - sp.diags(Qsym.diagonal())
+        del Qsym
+        del rows, cols, vals
+        gc.collect()
+    
+    # if ReducedSolve is False then the Q matrix is not shrunk and there is no point in multiplying it with anything.
+    if BigProblem is False:
+        # Reducing size of K matrix
+        if ReducedSolve is True:
+            Q11 = np.conj(np.transpose(u1Truncated)) @ Q @ u1Truncated
+            Q22 = np.conj(np.transpose(u2Truncated)) @ Q @ u2Truncated
+            Q33 = np.conj(np.transpose(u3Truncated)) @ Q @ u3Truncated
+            Q21 = np.conj(np.transpose(u2Truncated)) @ Q @ u1Truncated
+            Q31 = np.conj(np.transpose(u3Truncated)) @ Q @ u1Truncated
+            Q32 = np.conj(np.transpose(u3Truncated)) @ Q @ u2Truncated
+            
+        else:
+            Q11 = Q22 = Q33 = Q21 = Q31 = Q32 = Q
+    else:
+        # Reducing size of K matrix
+        QU1 = np.zeros([ndof2, cutoff], dtype=complex)
+        read_vec = GridFunction(fes2).vec.CreateVector()
+        write_vec = GridFunction(fes2).vec.CreateVector()
+        
+        # For each column in u1Truncated, post multiply with K. We then premultiply by appropriate vector to reduce size to MxM.
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u1Truncated[:, i]
+            with TaskManager():
+                K.Apply(read_vec, write_vec)
+            QU1[:, i] = write_vec.FV().NumPy()
+        Q11 = np.conj(np.transpose(u1Truncated)) @ QU1
+        Q21 = np.conj(np.transpose(u2Truncated)) @ QU1
+        Q31 = np.conj(np.transpose(u3Truncated)) @ QU1
+        del QU1
+        
+        # Same as before
+        QU2 = np.zeros([ndof2, cutoff], dtype=complex)
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u2Truncated[:, i]
+            with TaskManager():
+                K.Apply(read_vec, write_vec)
+            QU2[:, i] = write_vec.FV().NumPy()
+            Q22 = np.conj(np.transpose(u2Truncated)) @ QU2
+            Q32 = np.conj(np.transpose(u3Truncated)) @ QU2
+        del QU2
+        
+        # Same as before.
+        QU3 = np.zeros([ndof2, cutoff], dtype=complex)
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u3Truncated[:, i]
+            with TaskManager():
+                K.Apply(read_vec, write_vec)
+            QU3[:, i] = write_vec.FV().NumPy()
+            Q33 = np.conj(np.transpose(u3Truncated)) @ QU3
+
+                
+    # Computing Tensor Coefficients:
+    R = np.zeros([3, 3])
+    real_part = np.zeros((Sols.shape[1], 9))
+    
+    # For each frequency pre and post multiply Q with the solution vector for i=0:3, j=0:i+1.
+    for k in range(np.squeeze(Sols).shape[1]):
+        
+        
+        # if ReducedSolve is True then the matrices are small so we can just multiply them.
+        if ReducedSolve is True or BigProblem is False:
+            for i in range(3):
+                gi = np.squeeze(Sols[:,k,i])
+                for j in range(i + 1):
+
+                    Qij = locals()[f'Q{i+1}{j+1}']
+
+                    gj = np.squeeze(Sols[:, k, j])
+                    A = np.conj(gi[None, :]) @ Qij @ (gj)[:, None]
+                    R[i, j] = (A * (-alpha ** 3) / 4).real
+
+        # If we don't reduce the size of the matrix and we still want to save memory, then we can use K.Apply here as well.
+        if BigProblem is True and ReducedSolve is False:
+            for i in range(3):
+                gi = np.squeeze(Sols[:,k,i])
+                for j in range(i + 1):
+                    gj = np.squeeze(Sols[:, k, j])
+                    
+                    read_vec.FV().NumPy()[:] = gj
+                    with TaskManager():
+                        K.Apply(read_vec, write_vec)
+                        
+                    A = np.conj(gi[None,:]) @ write_vec.FV().NumPy()
+                    R[i, j] = (A * (-alpha ** 3) / 4).real
+                    
+        
+        R += np.transpose(R - np.diag(np.diag(R))).real
+        real_part[k,:] = R.flatten()
+    
+    return real_part

--- a/Functions/POD/Construct_Linear_System2.py
+++ b/Functions/POD/Construct_Linear_System2.py
@@ -1,0 +1,296 @@
+import numpy as np
+from ngsolve import *
+import scipy.sparse as sp
+import gc
+
+def Construct_Linear_System(Additional_Int_Order, BigProblem, Mu0, Theta0Sol, alpha, epsi, fes, fes2, inout, mu_inv, sigma,
+                  xivec, NumSolverThreads, drop_tol, u1Truncated, u2Truncated, u3Truncated, dom_nrs_metal, PODErrorBars):
+    
+    # print(help(a0.mat.COO))
+    # a0 = BilinearForm(fes2, symmetric=True, bonus_intorder=Additional_Int_Order, delete_zero_elements =drop_tol,keep_internal=False, symmetric_storage=True)
+    # a0 += SymbolicBFI((mu_inv) * InnerProduct(curl(u), curl(v)), bonus_intorder=Additional_Int_Order)
+    # a0 += SymbolicBFI((1j) * (1 - inout) * epsi * InnerProduct(u, v), bonus_intorder=Additional_Int_Order)
+    
+    # use_Assembly = True
+    
+    # Preallocation
+    print(' creating reduced order model', end='\r')
+    if NumSolverThreads != 'default':
+        SetNumThreads(NumSolverThreads)    
+    # Mu0=4*np.pi*10**(-7)
+    nu_no_omega = Mu0 * (alpha ** 2)
+    Theta_0 = GridFunction(fes)
+    u, v = fes2.TnT()
+    ndof2 = fes2.ndof
+    cutoff = u1Truncated.shape[1]
+
+    if PODErrorBars is True:
+        fes0 = HCurl(fes2.mesh, order=0, dirichlet="outer", complex=True, gradientdomains=dom_nrs_metal)
+        ndof0 = fes0.ndof
+        RerrorReduced1 = np.zeros([ndof0, cutoff * 2 + 1], dtype=complex)
+        RerrorReduced2 = np.zeros([ndof0, cutoff * 2 + 1], dtype=complex)
+        RerrorReduced3 = np.zeros([ndof0, cutoff * 2 + 1], dtype=complex)
+        ProH = GridFunction(fes2) # ProH and ProL are overwritten and reused for all 3 directions
+        ProL = GridFunction(fes0)
+        
+    else:
+        RerrorReduced1 = None
+        RerrorReduced2 = None
+        RerrorReduced3 = None
+        fes0 = None
+        ndof0 = None
+        ProL = None
+        
+
+    # Working on linear forms R1, R2, and R3
+    Theta_0 = GridFunction(fes2)
+
+    Theta_0.vec.FV().NumPy()[:] = Theta0Sol[:, 0]
+    r1 = LinearForm(fes2)
+    r1 += SymbolicLFI(inout * (-1j) * nu_no_omega * sigma * InnerProduct(Theta_0, v), bonus_intorder=Additional_Int_Order)
+    r1 += SymbolicLFI(inout * (-1j) * nu_no_omega * sigma * InnerProduct(xivec[0], v), bonus_intorder=Additional_Int_Order)
+    r1.Assemble()
+    R1 = r1.vec.FV().NumPy()
+    HR1 = (np.conjugate(np.transpose(u1Truncated)) @ np.transpose(R1))
+    
+    if PODErrorBars is True:
+        ProH.vec.FV().NumPy()[:] = R1
+        ProL.Set(ProH)
+        RerrorReduced1[:, 0] = ProL.vec.FV().NumPy()[:]
+        
+    del R1, r1
+
+
+    Theta_0.vec.FV().NumPy()[:] = Theta0Sol[:, 1]
+    r2 = LinearForm(fes2)
+    r2 += SymbolicLFI(inout * (-1j) * nu_no_omega * sigma * InnerProduct(Theta_0, v), bonus_intorder=Additional_Int_Order)
+    r2 += SymbolicLFI(inout * (-1j) * nu_no_omega * sigma * InnerProduct(xivec[1], v), bonus_intorder=Additional_Int_Order)
+    r2.Assemble()
+    R2 = r2.vec.FV().NumPy()
+    HR2 = (np.conjugate(np.transpose(u2Truncated)) @ np.transpose(R2))
+    
+    if PODErrorBars is True:
+        ProH.vec.FV().NumPy()[:] = R2
+        ProL.Set(ProH)
+        RerrorReduced2[:, 0] = ProL.vec.FV().NumPy()[:]
+    
+    del R2, r2
+    
+    
+    Theta_0.vec.FV().NumPy()[:] = Theta0Sol[:, 2]
+    r3 = LinearForm(fes2)
+    r3 += SymbolicLFI(inout * (-1j) * nu_no_omega * sigma * InnerProduct(Theta_0, v), bonus_intorder=Additional_Int_Order)
+    r3 += SymbolicLFI(inout * (-1j) * nu_no_omega * sigma * InnerProduct(xivec[2], v), bonus_intorder=Additional_Int_Order)
+    r3.Assemble()
+    R3 = r3.vec.FV().NumPy()
+    HR3 = (np.conjugate(np.transpose(u3Truncated)) @ np.transpose(R3))
+    
+    if PODErrorBars is True:
+        ProH.vec.FV().NumPy()[:] = R3
+        ProL.Set(ProH)
+        RerrorReduced3[:, 0] = ProL.vec.FV().NumPy()[:]
+        
+    del R3, r3
+
+
+
+    # Working on A0
+    a0 = BilinearForm(fes2, symmetric=True, bonus_intorder=Additional_Int_Order, delete_zero_elements =drop_tol,keep_internal=False, symmetric_storage=True)
+    a0 += SymbolicBFI((mu_inv) * InnerProduct(curl(u), curl(v)), bonus_intorder=Additional_Int_Order)
+    a0 += SymbolicBFI((1j) * (1 - inout) * epsi * InnerProduct(u, v), bonus_intorder=Additional_Int_Order)
+    
+    if BigProblem is False:
+        with TaskManager():
+            a0.Assemble()
+        rows, cols, vals = a0.mat.COO()
+        A0sym = sp.csr_matrix((vals, (rows, cols)),shape=(ndof2,ndof2))
+        del rows,cols,vals, a0
+        gc.collect()
+        A0 = A0sym + A0sym.T - sp.diags(A0sym.diagonal())
+        del A0sym
+    
+    # Compute smaller matrices (U^m_i)^H A0 U^m_i. Note that a0 is not fully assembled.
+    
+    if BigProblem is True:
+        #E1
+        A0H = np.zeros([ndof2, cutoff], dtype=complex)
+        read_vec = GridFunction(fes2).vec.CreateVector()
+        write_vec = GridFunction(fes2).vec.CreateVector()
+        
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u1Truncated[:, i]
+            with TaskManager():
+                a0.Apply(read_vec, write_vec)
+            A0H[:, i] = write_vec.FV().NumPy()
+        HA0H1 = (np.conjugate(np.transpose(u1Truncated)) @ A0H)
+        
+        if PODErrorBars is True:
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A0H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced1[:, i + 1] = ProL.vec.FV().NumPy()[:]
+        
+        #E2
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u2Truncated[:, i]
+            with TaskManager():
+                a0.Apply(read_vec, write_vec)
+            A0H[:, i] = write_vec.FV().NumPy()
+        HA0H2 = (np.conjugate(np.transpose(u2Truncated)) @ A0H)
+        
+        if PODErrorBars is True:
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A0H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced2[:, i + 1] = ProL.vec.FV().NumPy()[:]
+        
+        #E3
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u3Truncated[:, i]
+            with TaskManager():
+                a0.Apply(read_vec, write_vec)
+            A0H[:, i] = write_vec.FV().NumPy()
+        HA0H3 = (np.conjugate(np.transpose(u3Truncated)) @ A0H)
+        
+        if PODErrorBars is True:
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A0H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced3[:, i + 1] = ProL.vec.FV().NumPy()[:]
+
+        # ao and A0H are no longer needed.
+        del a0, A0H
+    else:
+        
+        if PODErrorBars is True:
+            A0H = A0 @ u1Truncated
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A0H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced1[:, i + 1] = ProL.vec.FV().NumPy()[:]
+                
+            A0H = A0 @ u2Truncated
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A0H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced2[:, i + 1] = ProL.vec.FV().NumPy()[:]
+                
+            A0H = A0 @ u3Truncated
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A0H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced3[:, i + 1] = ProL.vec.FV().NumPy()[:]
+            del A0H
+        
+        HA0H1 = np.conjugate(np.transpose(u1Truncated)) @ A0 @u1Truncated
+        HA0H2 = np.conjugate(np.transpose(u2Truncated)) @ A0 @u2Truncated
+        HA0H3 = np.conjugate(np.transpose(u3Truncated)) @ A0 @u3Truncated
+        del A0
+
+    
+    
+    # Working on A1
+    a1 = BilinearForm(fes2, symmetric=True, delete_zero_elements =drop_tol,keep_internal=False, symmetric_storage=True)
+    a1 += SymbolicBFI((1j) * inout * nu_no_omega * sigma * InnerProduct(u, v), bonus_intorder=Additional_Int_Order)
+    
+    if BigProblem is False:
+        with TaskManager():
+            a1.Assemble()
+        rows, cols, vals = a1.mat.COO()
+        A1sym = sp.csr_matrix((vals, (rows, cols)),shape=(ndof2,ndof2))
+        del rows,cols,vals, a1
+        gc.collect()
+        A1 = A1sym + A1sym.T - sp.diags(A1sym.diagonal())
+        del A1sym
+    
+    A1H = np.zeros([ndof2, cutoff], dtype=complex)
+
+    if BigProblem is True:
+        # Compute smaller matrices (U^m_i)^H A1 U^m_i.
+        #E1
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u1Truncated[:, i]
+            with TaskManager():
+                a1.Apply(read_vec, write_vec)
+            A1H[:, i] = write_vec.FV().NumPy()
+        HA1H1 = (np.conjugate(np.transpose(u1Truncated)) @ A1H)
+        
+        if PODErrorBars == True:
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A1H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced1[:, i + cutoff + 1] = ProL.vec.FV().NumPy()[:]
+        
+        #E2
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u2Truncated[:, i]
+            with TaskManager():
+                a1.Apply(read_vec, write_vec)
+            A1H[:, i] = write_vec.FV().NumPy()
+        HA1H2 = (np.conjugate(np.transpose(u2Truncated)) @ A1H)
+
+        if PODErrorBars == True:
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A1H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced2[:, i + cutoff + 1] = ProL.vec.FV().NumPy()[:]
+        
+        #E3
+        for i in range(cutoff):
+            read_vec.FV().NumPy()[:] = u3Truncated[:, i]
+            with TaskManager():
+                a1.Apply(read_vec, write_vec)
+            A1H[:, i] = write_vec.FV().NumPy()
+        HA1H3 = (np.conjugate(np.transpose(u3Truncated)) @ A1H)
+        
+        if PODErrorBars == True:
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A1H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced3[:, i + cutoff + 1] = ProL.vec.FV().NumPy()[:]
+        
+        
+        # a1 and A1H are no longer needed.
+        del a1, A1H, read_vec, write_vec
+    else:
+        
+        if PODErrorBars is True:
+            A1H = A1 @ u1Truncated
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A1H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced1[:, i + 1] = ProL.vec.FV().NumPy()[:]
+                
+            A1H = A1 @ u2Truncated
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A1H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced2[:, i + 1] = ProL.vec.FV().NumPy()[:]
+                
+            A1H = A1 @ u3Truncated
+            for i in range(cutoff):
+                ProH.vec.FV().NumPy()[:] = A1H[:, i]
+                ProL.Set(ProH)
+                RerrorReduced3[:, i + 1] = ProL.vec.FV().NumPy()[:]
+            del A1H
+            
+        HA1H1 = np.conjugate(np.transpose(u1Truncated)) @ A1 @u1Truncated
+        HA1H2 = np.conjugate(np.transpose(u2Truncated)) @ A1 @u2Truncated
+        HA1H3 = np.conjugate(np.transpose(u3Truncated)) @ A1 @u3Truncated
+        del A1
+
+    
+
+    return HA0H1, HA0H2, HA0H3, HA1H1, HA1H2, HA1H3, HR1, HR2, HR3, ProL, RerrorReduced1, RerrorReduced2, RerrorReduced3, fes0, ndof0
+    
+    # # Comparison
+    # a0.Assemble()
+    # rows, cols, vals = a0.mat.COO()
+    # A0sym = sp.csr_matrix((vals, (rows, cols)),shape=(ndof2,ndof2))
+    # del rows,cols,vals, a0
+    # gc.collect()
+    # A0 = A0sym + A0sym.T - sp.diags(A0sym.diagonal())
+    # del A0sym
+
+    # A0H_2 = np.zeros([ndof2, cutoff], dtype=complex)
+    # A0H_2 = A0@u1Truncated

--- a/Functions/POD/PODSweepMulti.py
+++ b/Functions/POD/PODSweepMulti.py
@@ -516,57 +516,13 @@ def PODSweepMulti(Object, Order, alpha, inorout, mur, sig, Array, PODArray, PODT
         writer.writeheader()
         writer.writerow(timing_dictionary)
 
-  # Computing additional terms for testing commutator
-    compute_additional_terms = False
-    if compute_additional_terms is True:
-        Theta1Sols = np.zeros((ndof, len(Array),3), dtype=complex)
-    
-        Theta1Sols[:,:,0] = u1Truncated @ (g[:,:,0])
-        Theta1Sols[:,:,1] = u2Truncated @ (g[:,:,1])
-        Theta1Sols[:,:,2] = u3Truncated @ (g[:,:,2])
-    
-        #term1, term2, term3, term4, Z_upper_bound, Z_tilde_upper_bound = test_reg(Theta0Sol, fes2, Theta1Sols, 6, xivec, inout, epsi, alpha, Array, TensorArray, Integration_Order,
-        #                                                        mu_inv, sigma, N0)
-        # term1_sym = np.zeros(term1.shape, dtype=complex)
-        # term2_sym = np.zeros(term2.shape, dtype=complex)
-        # term3_sym = np.zeros(term3.shape, dtype=complex)
-        # for k in range(len(PODArray)):
-        #     term1_sym[k,:,:] = -(np.squeeze(term1[k,:,:]) + np.transpose(np.squeeze(term1[k, :, :])))/2
-        #     term2_sym[k,:,:] = (np.squeeze(term2[k,:,:]) + np.transpose(np.squeeze(term2[k, :, :])))/2
-        #     term3_sym[k,:,:] = -(np.squeeze(term3[k,:,:]) + np.transpose(np.squeeze(term3[k, :, :])))/2
-            #PODTensors[k,:] = PODTensors[k, :] + term1_sym[k,:,:].ravel() + term2_sym[k,:,:].ravel() + term3_sym[k,:,:].ravel() 
-            #PODTensors = np.asarray(PODTensors)
-        
-        # np.savetxt('Z_upper_bound.csv', Z_upper_bound)
-        # np.savetxt('Z_tilde_upper_bound.csv', Z_tilde_upper_bound)
-        # shutil.copy('sum_reg_terms_real.csv', f'Results/{sweepname}/Data/sum_reg_terms_real.csv')
-        # shutil.copy('sum_reg_terms_imag.csv', f'Results/{sweepname}/Data/sum_reg_terms_imag.csv')
-        # shutil.copy('Z_upper_bound.csv', f'Results/{sweepname}/Data/Z_upper_bound.csv')
-        # shutil.copy('Z_tilde_upper_bound.csv', f'Results/{sweepname}/Data/Z_tilde_upper_bound.csv')
 
 
     real_part = Mat_Method_Calc_Real_Part(bilinear_bonus_int_order, fes2, inout, mu_inv, alpha, np.squeeze(np.asarray(Lower_Sols)),
             u1Truncated, u2Truncated, u3Truncated, NumSolverThreads, drop_tol, BigProblem, ReducedSolve=True)
     
-    imag_part = Mat_Method_Calc_Imag_Part(Array,
-                                          Integration_Order,
-                                          Theta0Sol,
-                                          bilinear_bonus_int_order,
-                                          fes2,
-                                          mesh,
-                                          inout,
-                                          mu_inv,
-                                          alpha, 
-                                          np.squeeze(np.asarray(Lower_Sols)),
-                                          sigma,
-                                          u1Truncated,
-                                          u2Truncated,
-                                          u3Truncated,
-                                          xivec, 
-                                          NumSolverThreads,
-                                          drop_tol,
-                                          BigProblem,
-                                          ReducedSolve=True)
+    imag_part = Mat_Method_Calc_Imag_Part(Array, Integration_Order, Theta0Sol, bilinear_bonus_int_order, fes2, mesh, inout, alpha, np.squeeze(np.asarray(Lower_Sols)),
+            sigma, u1Truncated, u2Truncated, u3Truncated, xivec, NumSolverThreads, drop_tol, BigProblem, ReducedSolve=True)
 
     if PlotPod == True:
         if PODErrorBars == True:

--- a/Functions/POD/PODSweepMulti.py
+++ b/Functions/POD/PODSweepMulti.py
@@ -195,30 +195,44 @@ def PODSweepMulti(Object, Order, alpha, inorout, mur, sig, Array, PODArray, PODT
 
         if use_integral is False and PlotPod is True:
             
-            # Test and trial functions
-            u, v = fes2.TnT()
+            # # Test and trial functions
+            # u, v = fes2.TnT()
             U_proxy = sp.eye(fes2.ndof)
-            #ReducedSolve=False
-            print(drop_tol)
-            At0_array, EU_array_conj, Q_array, T_array, UAt0U_array, UAt0_conj, UH_array, c1_array, c5_array, c7, c8_array = Construct_Matrices(
-            Integration_Order, Theta0Sol, bilinear_bonus_int_order, fes2, inout, mesh, mu_inv, sigma, '', u,
-            U_proxy, U_proxy, U_proxy, v, xivec, NumSolverThreads, drop_tol,  ReducedSolve=False)
+            # #ReducedSolve=False
+            # print(drop_tol)
+            # At0_array, EU_array_conj, Q_array, T_array, UAt0U_array, UAt0_conj, UH_array, c1_array, c5_array, c7, c8_array = Construct_Matrices(
+            # Integration_Order, Theta0Sol, bilinear_bonus_int_order, fes2, inout, mesh, mu_inv, sigma, '', u,
+            # U_proxy, U_proxy, U_proxy, v, xivec, NumSolverThreads, drop_tol,  ReducedSolve=False)
         
-            del U_proxy
+            # del U_proxy
         
-            PODTensors, _ = Theta1_Lower_Sweep_Mat_Method(PODArray, Q_array, c1_array, c5_array, c7, c8_array, At0_array, UAt0_conj,
-                                UAt0U_array, T_array, EU_array_conj, UH_array, Theta1Sols, [], '',
-                                fes2.ndof,
-                                alpha, False)
+            # PODTensors, _ = Theta1_Lower_Sweep_Mat_Method(PODArray, Q_array, c1_array, c5_array, c7, c8_array, At0_array, UAt0_conj,
+            #                     UAt0U_array, T_array, EU_array_conj, UH_array, Theta1Sols, [], '',
+            #                     fes2.ndof,
+            #                     alpha, False)
         
-            del At0_array, EU_array_conj, Q_array, T_array, UAt0U_array, UAt0_conj, UH_array, c1_array, c5_array, c7, c8_array
+            # del At0_array, EU_array_conj, Q_array, T_array, UAt0U_array, UAt0_conj, UH_array, c1_array, c5_array, c7, c8_array
             
-            for k in range(PODTensors.shape[0]):
-                R = PODTensors[k,:].reshape(3,3).real
-                I = PODTensors[k,:].reshape(3,3).imag
-                PODEigenValues[k, :] = np.sort(np.linalg.eigvals(N0 + R)) + 1j * np.sort(np.linalg.eigvals(I))
+            # for k in range(PODTensors.shape[0]):
+            #     R = PODTensors[k,:].reshape(3,3).real
+            #     I = PODTensors[k,:].reshape(3,3).imag
+            #     PODEigenValues[k, :] = np.sort(np.linalg.eigvals(N0 + R)) + 1j * np.sort(np.linalg.eigvals(I))
             
-                PODTensors[k,:] = PODTensors[k,:] + N0.reshape(1,9)
+            #     PODTensors[k,:] = PODTensors[k,:] + N0.reshape(1,9)
+            
+            real_part = Mat_Method_Calc_Real_Part(bilinear_bonus_int_order, fes2, inout, mu_inv, alpha, np.squeeze(np.asarray(Theta1Sols)),
+                U_proxy, U_proxy, U_proxy, NumSolverThreads, drop_tol, BigProblem, ReducedSolve=False)
+
+            imag_part = Mat_Method_Calc_Imag_Part(PODArray, Integration_Order, Theta0Sol, bilinear_bonus_int_order, fes2, mesh, inout, alpha, 
+                np.squeeze(np.asarray(Theta1Sols)), sigma, U_proxy, U_proxy, U_proxy, xivec,  NumSolverThreads, drop_tol, BigProblem, ReducedSolve=False)
+            
+            for Num in range(len(PODArray)):
+                PODTensors[Num, :] = real_part[Num,:] + N0.flatten()
+                PODTensors[Num, :] += 1j * imag_part[Num,:]
+
+                R = PODTensors[Num, :].real.reshape(3, 3)
+                I = PODTensors[Num, :].imag.reshape(3, 3)
+                PODEigenValues[Num, :] = np.sort(np.linalg.eigvals(R)) + 1j * np.sort(np.linalg.eigvals(I))
         
         timing_dictionary['Theta1'] = time.time()
 


### PR DESCRIPTION
Using the A.Apply() method, we've been able to avoid assembling the large bilinear forms used in the postprocessing and POD steps. This is currently slower than assembling the entire matrix, but more memory efficient.

I've also split the computation of (R)_ij and (I)_ij into two different functions. This means that the large bilinear forms for the real and imag parts are not both in memory together.

Proposed changes have passed the standard tests.